### PR TITLE
Avoid extension URNs get caught as paths

### DIFF
--- a/shared/path.go
+++ b/shared/path.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -41,6 +42,8 @@ const (
 	Parenthesis
 )
 
+var reg, regerr = regexp.Compile("^(?i)([a-z]+:)+2")
+
 // create a new Path from text
 func NewPath(text string) (Path, error) {
 	text = strings.TrimSpace(text)
@@ -60,7 +63,7 @@ func NewPath(text string) (Path, error) {
 		case quoteRune:
 			textMode = !textMode
 		case periodRune:
-			if !textMode && strings.ToLower(text[:i]) != "urn:ietf:params:scim:schemas:core:2" {
+			if !textMode && !reg.MatchString(text) {
 				idx = i
 				break
 			}


### PR DESCRIPTION
Refs #2.

This way we can create (also if there is not yet a straightforward extension mechanism already built in) an extension - eg., the canonical enterprise user extension (also represented in the RFC).

And submit a body like the following one.

```json
{
  "schemas": [
    "urn:ietf:params:scim:schemas:core:2.0:User", 
    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
  ],
  "userName": "qwerty",
  "name":{
    "familyName":"qwerty",
    "givenName":"uiop"
  },
  "emails": [
    {
      "value": "qwerty@uiop.com",
      "type": "work",
      "primary": true
    }
  ],
 "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
	"employeeNumber": "2B"
  }
}
```

Please note that current PR only ensures that the key **"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"** (and keys following this typical format) does not get broken on the **dot** by the path component.