### PR TITLE
Exactly match base and next also for extension URNs

### DIFF
--- a/shared/path.go
+++ b/shared/path.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -41,6 +42,8 @@ const (
 	Parenthesis
 )
 
+var reg, _ = regexp.Compile("^(?i)([a-z]+:)+2$")
+
 // create a new Path from text
 func NewPath(text string) (Path, error) {
 	text = strings.TrimSpace(text)
@@ -60,7 +63,7 @@ func NewPath(text string) (Path, error) {
 		case quoteRune:
 			textMode = !textMode
 		case periodRune:
-			if !textMode && strings.ToLower(text[:i]) != "urn:ietf:params:scim:schemas:core:2" {
+			if !textMode && !reg.MatchString(text[:i]) {
 				idx = i
 				break
 			}

--- a/shared/path_test.go
+++ b/shared/path_test.go
@@ -90,6 +90,26 @@ func TestNewPath(t *testing.T) {
 				assert.Nil(t, head.Next().Next())
 			},
 		},
+		{
+			// urn path
+			"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+			func(head Path, err error) {
+				assert.Nil(t, err)
+				assert.NotNil(t, head)
+				assert.Equal(t, "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", head.Base())
+				assert.Nil(t, head.Next())
+			},
+		},
+		{
+			// urn path
+			"urn:ietf:params:scim:schemas:extension:account:2.0:Password",
+			func(head Path, err error) {
+				assert.Nil(t, err)
+				assert.NotNil(t, head)
+				assert.Equal(t, "urn:ietf:params:scim:schemas:extension:account:2.0:Password", head.Base())
+				assert.Nil(t, head.Next())
+			},
+		},
 	} {
 		test.assertion(NewPath(test.text))
 	}

--- a/shared/path_test.go
+++ b/shared/path_test.go
@@ -2,10 +2,11 @@ package shared
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPath(t *testing.T) {


### PR DESCRIPTION
Hi @davidiamyou,

following your considerations to my previous PR #3 I upgraded the regular expression and the match parameter so to perform an exact match.

This ways all the test cases within `path_test.go` pass.

And library supports also the extension URNs.