### PR TITLE
Added support implicit path in replace operation

### DIFF
--- a/shared/patch_test.go
+++ b/shared/patch_test.go
@@ -91,6 +91,15 @@ func TestApplyPatch(t *testing.T) {
 			},
 		},
 		{
+			// replace: implicit path
+			Patch{Op: Replace, Value: map[string]interface{}{"userName": "foo", "externalId": "bar"}},
+			func(r *Resource, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, "foo", r.GetData()["userName"])
+				assert.Equal(t, "bar", r.GetData()["externalId"])
+			},
+		},
+		{
 			// replace: duplex path
 			Patch{Op: Replace, Path: "name.familyName", Value: "foo"},
 			func(r *Resource, err error) {


### PR DESCRIPTION
According [specification](https://tools.ietf.org/html/rfc7644#section-3.5.2.3) replace operation should support implicit path

> If the "path" parameter is omitted, the target is assumed to be
>       the resource itself.  In this case, the "value" attribute SHALL
>       contain a list of one or more attributes that are to be replaced.