### PR TITLE
Small fixes needed to run

### DIFF
--- a/protocol/handler/query.go
+++ b/protocol/handler/query.go
@@ -55,6 +55,9 @@ func (h *Query) parseRequest(request http.Request) (qr *services.QueryRequest, e
 				Order: crud.SortOrder(request.QueryParam(sortOrder)),
 			}
 		}
+		if len(request.QueryParam(filter)) > 0 {
+			qr.Filter = request.QueryParam(filter)
+		}
 		if len(request.QueryParam(attributes)) > 0 || len(request.QueryParam(excludedAttributes)) > 0 {
 			qr.Projection = &crud.Projection{}
 			if v := strings.TrimSpace(request.QueryParam(attributes)); len(v) > 0 {

--- a/server/api/cmd.go
+++ b/server/api/cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/imulab/go-scim/protocol/log"
+	"github.com/imulab/go-scim/server/args"
 	"github.com/julienschmidt/httprouter"
 	"github.com/urfave/cli/v2"
 	"net/http"
@@ -11,7 +12,14 @@ import (
 
 // Return a command to start a process of serving SCIM HTTP API.
 func Command() *cli.Command {
-	ag := new(arguments)
+	ag := &arguments{
+		Scim:     &args.Scim{},
+		Memory:   &args.Memory{},
+		Mongo:    &args.Mongo{},
+		Rabbit:   &args.Rabbit{},
+		Log:      &args.Log{},
+		httpPort: 0,
+	}
 	return &cli.Command{
 		Name:        "api",
 		Usage:       "Serves API for SCIM (Simple Cloud Identity Management) protocol",

--- a/server/api/context.go
+++ b/server/api/context.go
@@ -164,7 +164,7 @@ func (c *appContext) loadGroupHandlers() {
 	c.groupCreateHandler = &handler.Create{
 		Log:          c.logger,
 		Service:      c.groupCreateService,
-		ResourceType: c.userResourceType,
+		ResourceType: c.groupResourceType,
 	}
 	c.groupReplaceHandler = &handler.Replace{
 		Log:                 c.logger,
@@ -317,6 +317,6 @@ func (c *appContext) loadGroupDatabase(args *arguments) {
 		c.groupDatabase = db.Memory()
 	} else {
 		coll := c.mongoClient.Database(args.Mongo.Database, options.Database()).Collection(c.groupResourceType.Name(), options.Collection())
-		c.userDatabase = scimmongo.DB(c.groupResourceType, c.logger, coll, scimmongo.Options())
+		c.groupDatabase = scimmongo.DB(c.groupResourceType, c.logger, coll, scimmongo.Options())
 	}
 }

--- a/server/groupsync/cmd.go
+++ b/server/groupsync/cmd.go
@@ -3,6 +3,7 @@ package groupsync
 import (
 	"context"
 	"github.com/imulab/go-scim/protocol/log"
+	"github.com/imulab/go-scim/server/args"
 	"github.com/urfave/cli/v2"
 	"os"
 	"os/signal"
@@ -11,7 +12,14 @@ import (
 
 // Return a command that starts a process to synchronize group membership of user resources.
 func Command() *cli.Command {
-	ag := new(arguments)
+	ag := &arguments{
+		Scim:     &args.Scim{},
+		Memory:   &args.Memory{},
+		Mongo:    &args.Mongo{},
+		Rabbit:   &args.Rabbit{},
+		Log:      &args.Log{},
+		requeueLimit: 0,
+	}
 	return &cli.Command{
 		Name:        "group-sync",
 		Aliases:     []string{"gs", "sync"},

--- a/server/groupsync/context.go
+++ b/server/groupsync/context.go
@@ -94,9 +94,9 @@ func (c *appContext) loadUserDatabase(args *arguments) {
 
 func (c *appContext) loadGroupDatabase(args *arguments) {
 	if args.MemoryDB {
-		c.userDB = db.Memory()
+		c.groupDB = db.Memory()
 	} else {
 		coll := c.mongoClient.Database(args.Mongo.Database, options.Database()).Collection(c.groupResourceType.Name(), options.Collection())
-		c.userDB = scimmongo.DB(c.groupResourceType, c.logger, coll, scimmongo.Options())
+		c.groupDB = scimmongo.DB(c.groupResourceType, c.logger, coll, scimmongo.Options())
 	}
 }


### PR DESCRIPTION
Here I only needed to make a few changes to get up and running:

- I wanted to accept filter queries on get requests via url query parameters
- Had to expand `new(arguments)` using a literal to avoid a panic at start (maybe we need a constructor?)
- Group handler and db assignments just needed to be set to the right places with the right stuff

I do have a question about the `Replace` signature on the DB interface. In practice I find that the resource is modified before being passed to this method, such that (using mongo) when `Version()` is called on the resource inside `Replace` the object lookup fails because the new version for that resource does not exist yet. I have a branch where I modified the signature to include the `oldVersion`, so that `Replace` can lookup the old resource successfully before saving the new version of the resource.

Would you be willing to accept a pull request introducing this, or do you have designs around how this particular case should be solved?

In addition to this, I use Docker and Docker Compose for local development. I have a Makefile, Dockerfile and docker-compose.yml built for this project. Would you be willing to accept a pull request introducing these?