### PR TITLE
Introduce working example with docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+##########################################################################
+# GO BUILDER
+##########################################################################
+FROM golang:1.13-buster AS builder
+
+WORKDIR /build/scim
+
+COPY . ./
+
+WORKDIR /build/scim/server
+
+RUN make build
+
+##########################################################################
+# FINAL IMAGE
+##########################################################################
+FROM debian:buster-slim
+
+RUN apt-get -yq update \
+  && apt-get -yq install ca-certificates curl openssl \
+  && apt-get -yq autoremove \
+  && apt-get -yq clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && truncate -s 0 /var/log/*log
+
+# copy binary
+COPY --from=builder /build/scim/server/bin/linux_amd64/scim /usr/bin/scim
+
+##########################################################################
+# Copying resource files between containers
+# We should be using a bindata tool, like github.com/markbates/pkger
+##########################################################################
+
+# copy schemas
+COPY --from=builder /build/scim/server/public/schemas /usr/share/scim/schemas
+
+# copy resource types
+COPY --from=builder /build/scim/server/public/resource_types /usr/share/scim/resource_types
+
+# copy service provider configuration
+COPY --from=builder /build/scim/server/public/sp_config /usr/share/scim/sp_config
+
+# copy mongo metadata
+COPY --from=builder /build/scim/mongo/public /usr/share/scim/mongo_metadata
+
+# run binary
+CMD ["/usr/bin/scim"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ The project is in the early stage of `v2.0.0`. As for now, to check out the func
 $ go test ./...
 ```
 
+To check out a functioning server, using the provided example configuration files:
+
+###### *Requirements:* [Docker](https://docs.docker.com/get-started/) and [Docker Compose](https://docs.docker.com/compose/gettingstarted/)
+
+```
+# cd into server
+$ docker-compose up --build
+```
+
 ## Migration to Go modules
 
 Since `v2.0.0-m3`, the project has migrated from [dep](https://golang.github.io/dep/) to [go modules](https://github.com/golang/go/wiki/Modules). This allows users to import the exact project modules separately as needed, and also allows their functions to evolve independently.

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,0 +1,45 @@
+.PHONY: all build deps binary test
+
+OK_COLOR=\033[32;01m
+NO_COLOR=\033[0m
+ERROR_COLOR=\033[31;01m
+WARN_COLOR=\033[33;01m
+
+NOW = $(shell date -u '+%Y%m%d%I%M%S')
+
+DOCKER := docker
+GO := go
+GO_ENV := $(shell $(GO) env GOOS GOARCH)
+GOOS ?= $(word 1,$(GO_ENV))
+GOARCH ?= $(word 2,$(GO_ENV))
+GOFLAGS ?= $(GOFLAGS:)
+ROOT_DIR := $(realpath .)
+
+# GOOS/GOARCH of the build host, used to determine whether we're cross-compiling or not
+BUILDER_GOOS_GOARCH="$(GOOS)_$(GOARCH)"
+
+ifneq ($(GOOS), darwin)
+	# EXTLDFLAGS = -extldflags "-lm -lstdc++ -static"
+	EXTLDFLAGS =
+else
+	EXTLDFLAGS =
+endif
+
+GO_LINKER_FLAGS ?= --ldflags \
+	'$(EXTLDFLAGS) -s -w '
+
+all: build
+
+build: deps binary
+
+deps:
+	@echo "$(OK_COLOR)==> Fetching dependencies...$(NO_COLOR)"
+	$(GO) mod download
+
+binary:
+	@echo "$(OK_COLOR)==> Building binary ($(GOOS)/$(GOARCH))...$(NO_COLOR)"
+	$(GO) build -a $(GOFLAGS) $(GO_LINKER_FLAGS) -o bin/$(GOOS)_$(GOARCH)/scim
+
+test: deps
+	@echo "$(OK_COLOR)==> Running tests...$(NO_COLOR)"
+	$(GO) test $(GOFLAGS) -race ./...

--- a/server/args/retry.go
+++ b/server/args/retry.go
@@ -1,0 +1,49 @@
+package args
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Retry returns a function that runs the specified callback as many times as it can (no more
+// frequently than once every interval) until the timeout has past. The context passed to the
+// callback is not canceled when the timeout expires.
+func Retry(timeout time.Duration, interval time.Duration, callback func(ctx context.Context) error) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		var err error
+		t := newInstantTicker(interval)
+		defer t.Stop()
+		timedCtx, timedCtxCancel := context.WithTimeout(ctx, timeout)
+		for {
+			select {
+			case <-timedCtx.Done():
+				timedCtxCancel()
+				return errors.Wrap(err, "timeout exceded")
+			case <-t.C:
+				// Use the original context, not the one with the timeout for how long to retry for.
+				err = callback(ctx)
+				if err != nil {
+					continue
+				}
+				timedCtxCancel()
+				return nil
+			}
+		}
+	}
+}
+
+func newInstantTicker(repeat time.Duration) *time.Ticker {
+	ticker := time.NewTicker(repeat)
+	oc := ticker.C
+	nc := make(chan time.Time, 1)
+	go func() {
+		nc <- time.Now()
+		for tm := range oc {
+			nc <- tm
+		}
+	}()
+	ticker.C = nc
+	return ticker
+}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,105 @@
+version: "3"
+services:
+  mediainit:
+    image: alpine:3.10
+    entrypoint: /bin/sh -c "chown -v nobody:nogroup /data/db && chmod -v 777 /data/db"
+    container_name: mediainit
+    restart: "no"
+    volumes:
+      - 'mongo_data:/data/db'
+
+  db:
+    image: "bitnami/mongodb:latest"
+    environment:
+      - MONGODB_EXTRA_FLAGS=--wiredTigerCacheSizeGB=2 --bind_ip_all
+      - MONGODB_USERNAME=user
+      - MONGODB_PASSWORD=password123
+      - MONGODB_DATABASE=scim_database
+    volumes:
+      - 'mongo_data:/data/db'
+    ports:
+      - '27017:27017'
+    networks:
+      - app-tier
+
+  rabbit:
+    image: "bitnami/rabbitmq:latest"
+    environment:
+      - RABBITMQ_USERNAME=user
+      - RABBITMQ_PASSWORD=password123
+      - RABBITMQ_NODE_NAME=user@rabbit
+    ports:
+      - '4369:4369'
+      - '5672:5672'
+      - '25672:25672'
+      - '15672:15672'
+    networks:
+      - app-tier
+    volumes:
+      - 'rabbitmq_data:/bitnami'
+
+  group:
+    image: scim
+    command: ["/usr/bin/scim", "group-sync"]
+    environment:
+      - REQUEUE_LIMIT=1
+      - MONGO_HOST=db
+      - MONGO_PORT=27017
+      - MONGO_USERNAME=user
+      - MONGO_PASSWORD=password123
+      - MONGO_DATABASE=scim_database
+      - MONGO_OPT=authMechanism=SCRAM-SHA-1
+      - RABBIT_HOST=rabbit
+      - RABBIT_PORT=5672
+      - RABBIT_USERNAME=user
+      - RABBIT_PASSWORD=password123
+      - USER_RESOURCE_TYPE=/usr/share/scim/resource_types/user.json
+      - GROUP_RESOURCE_TYPE=/usr/share/scim/resource_types/group.json
+      - SCHEMAS_FOLDER=/usr/share/scim/schemas
+      - SERVICE_PROVIDER_CONFIG=/usr/share/scim/sp_config/sp_config.json
+      - MONGO_METADATA_FOLDER=/usr/share/scim/mongo_metadata
+    networks:
+      - app-tier
+    depends_on:
+      - db
+      - rabbit
+
+  server:
+    image: scim
+    build:
+      context: ../.
+    command: ["/usr/bin/scim", "api"]
+    environment:
+      - HTTP_PORT=5000
+      - MONGO_HOST=db
+      - MONGO_PORT=27017
+      - MONGO_USERNAME=user
+      - MONGO_PASSWORD=password123
+      - MONGO_DATABASE=scim_database
+      - MONGO_OPT=authMechanism=SCRAM-SHA-1
+      - RABBIT_HOST=rabbit
+      - RABBIT_PORT=5672
+      - RABBIT_USERNAME=user
+      - RABBIT_PASSWORD=password123
+      - USER_RESOURCE_TYPE=/usr/share/scim/resource_types/user.json
+      - GROUP_RESOURCE_TYPE=/usr/share/scim/resource_types/group.json
+      - SCHEMAS_FOLDER=/usr/share/scim/schemas
+      - SERVICE_PROVIDER_CONFIG=/usr/share/scim/sp_config/sp_config.json
+      - MONGO_METADATA_FOLDER=/usr/share/scim/mongo_metadata
+    ports:
+      - "5000:5000"
+    networks:
+      - app-tier
+    depends_on:
+      - db
+      - rabbit
+
+volumes:
+  rabbitmq_data:
+    driver: local
+  mongo_data:
+    driver: local
+
+networks:
+  app-tier:
+    driver: bridge

--- a/server/public/resource_types/group.json
+++ b/server/public/resource_types/group.json
@@ -1,0 +1,7 @@
+{
+  "id": "Group",
+  "name": "Group",
+  "endpoint": "/Groups",
+  "description": "Group resource type",
+  "schema": "urn:ietf:params:scim:schemas:core:2.0:Group"
+}

--- a/server/public/resource_types/user.json
+++ b/server/public/resource_types/user.json
@@ -1,0 +1,13 @@
+{
+  "id": "User",
+  "name": "User",
+  "description": "User resource type",
+  "endpoint": "/Users",
+  "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
+  "schemaExtensions": [
+    {
+      "schema": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+      "required": false
+    }
+  ]
+}

--- a/server/public/schemas/group_schema.json
+++ b/server/public/schemas/group_schema.json
@@ -1,0 +1,65 @@
+{
+  "id": "urn:ietf:params:scim:schemas:core:2.0:Group",
+  "name": "Group",
+  "description": "Defined attributes for the group schema",
+  "attributes": [
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:Group:displayName",
+      "name": "displayName",
+      "type": "string",
+      "required": true,
+      "uniqueness": "server",
+      "_index": 100,
+      "_path": "displayName"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:Group:groups",
+      "name": "members",
+      "type": "complex",
+      "multiValued": true,
+      "mutability": "readOnly",
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:Group:members.value",
+          "name": "value",
+          "type": "string",
+          "mutability": "readOnly",
+          "_index": 0,
+          "_path": "members.value",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:Group:members.$ref",
+          "name": "$ref",
+          "type": "reference",
+          "mutability": "readOnly",
+          "_index": 1,
+          "_path": "members.$ref",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:Group:members.type",
+          "name": "type",
+          "type": "string",
+          "mutability": "readOnly",
+          "canonicalValues": [
+            "direct",
+            "indirect"
+          ],
+          "_index": 2,
+          "_path": "members.type"
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:Group:members.display",
+          "name": "display",
+          "type": "string",
+          "mutability": "readOnly",
+          "_index": 3,
+          "_path": "members.display"
+        }
+      ],
+      "_index": 101,
+      "_path": "members"
+    }
+  ]
+}

--- a/server/public/schemas/user_enterprise_extension_schema.json
+++ b/server/public/schemas/user_enterprise_extension_schema.json
@@ -1,0 +1,72 @@
+{
+  "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+  "name": "EnterpriseUser",
+  "description": "Defined attributes for the user enterprise extension schema",
+  "attributes": [
+    {
+      "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber",
+      "name": "employeeNumber",
+      "type": "string",
+      "_index": 100,
+      "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:costCenter",
+      "name": "costCenter",
+      "type": "string",
+      "_index": 101,
+      "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:costCenter"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:organization",
+      "name": "organization",
+      "type": "string",
+      "_index": 102,
+      "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:organization"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:division",
+      "name": "division",
+      "type": "string",
+      "_index": 103,
+      "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:division"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department",
+      "name": "department",
+      "type": "string",
+      "_index": 104,
+      "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager",
+      "name": "manager",
+      "type": "complex",
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.value",
+          "name": "value",
+          "type": "string",
+          "_index": 0,
+          "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.value"
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.$ref",
+          "name": "$ref",
+          "type": "reference",
+          "_index": 1,
+          "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.$ref"
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName",
+          "name": "displayName",
+          "type": "string",
+          "_index": 2,
+          "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName"
+        }
+      ],
+      "_index": 105,
+      "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager"
+    }
+  ]
+}

--- a/server/public/schemas/user_schema.json
+++ b/server/public/schemas/user_schema.json
@@ -1,0 +1,643 @@
+{
+  "id": "urn:ietf:params:scim:schemas:core:2.0:User",
+  "name": "User",
+  "description": "Defined attributes for the user schema",
+  "attributes": [
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:userName",
+      "name": "userName",
+      "type": "string",
+      "required": true,
+      "uniqueness": "server",
+      "_index": 100,
+      "_path": "userName"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:name",
+      "name": "name",
+      "type": "complex",
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:name.formatted",
+          "name": "formatted",
+          "type": "string",
+          "_index": 0,
+          "_path": "name.formatted",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:name.familyName",
+          "name": "familyName",
+          "type": "string",
+          "_index": 1,
+          "_path": "name.familyName",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:name.givenName",
+          "name": "givenName",
+          "type": "string",
+          "_index": 2,
+          "_path": "name.givenName",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:name.middleName",
+          "name": "middleName",
+          "type": "string",
+          "_index": 3,
+          "_path": "name.middleName",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:name.honorificPrefix",
+          "name": "honorificPrefix",
+          "type": "string",
+          "_index": 4,
+          "_path": "name.honorificPrefix",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:name.honorificSuffix",
+          "name": "honorificSuffix",
+          "type": "string",
+          "_index": 5,
+          "_path": "name.honorificSuffix",
+          "_annotations": ["@Identity"]
+        }
+      ],
+      "_index": 101,
+      "_path": "name"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:displayName",
+      "name": "displayName",
+      "type": "string",
+      "_index": 102,
+      "_path": "displayName"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:nickName",
+      "name": "nickName",
+      "type": "string",
+      "_index": 103,
+      "_path": "nickName"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:profileUrl",
+      "name": "profileUrl",
+      "type": "reference",
+      "referenceTypes": [
+        "external"
+      ],
+      "_index": 104,
+      "_path": "profileUrl"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:title",
+      "name": "title",
+      "type": "string",
+      "_index": 105,
+      "_path": "title"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:userType",
+      "name": "userType",
+      "type": "string",
+      "canonicalValues": [
+        "Contractor",
+        "Employee",
+        "Intern",
+        "Temp",
+        "External",
+        "Internal",
+        "Unknown"
+      ],
+      "_index": 106,
+      "_path": "userType"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:preferredLanguage",
+      "name": "preferredLanguage",
+      "type": "string",
+      "canonicalValues": [
+        "zh_CN",
+        "en_US",
+        "en_CA"
+      ],
+      "_index": 107,
+      "_path": "preferredLanguage"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:locale",
+      "name": "locale",
+      "type": "string",
+      "canonicalValues": [
+        "en_CA",
+        "fr_CA",
+        "en_US",
+        "zh_CN"
+      ],
+      "_index": 108,
+      "_path": "locale"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:timezone",
+      "name": "timezone",
+      "type": "string",
+      "canonicalValues": [
+        "Asia/Shanghai",
+        "Asia/Beijing",
+        "America/New_York",
+        "America/Toronto"
+      ],
+      "_index": 109,
+      "_path": "timezone"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:active",
+      "name": "active",
+      "type": "boolean",
+      "_index": 110,
+      "_path": "active"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:password",
+      "name": "password",
+      "type": "string",
+      "mutability": "writeOnly",
+      "returned": "never",
+      "_index": 111,
+      "_path": "password"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:emails",
+      "name": "emails",
+      "type": "complex",
+      "multiValued": true,
+      "required": true,
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:emails.value",
+          "name": "value",
+          "type": "string",
+          "_index": 0,
+          "_path": "emails.value",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:emails.type",
+          "name": "type",
+          "type": "string",
+          "canonicalValues": [
+            "work",
+            "home",
+            "other"
+          ],
+          "_index": 1,
+          "_path": "emails.type",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:emails.primary",
+          "name": "primary",
+          "type": "boolean",
+          "_index": 2,
+          "_path": "emails.primary",
+          "_annotations": ["@Primary"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:emails.display",
+          "name": "display",
+          "type": "string",
+          "_index": 3,
+          "_path": "emails.display"
+        }
+      ],
+      "_index": 112,
+      "_path": "emails",
+      "_annotations": [
+        "@AutoCompact",
+        "@ExclusivePrimary"
+      ]
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers",
+      "name": "phoneNumbers",
+      "type": "complex",
+      "multiValued": true,
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.value",
+          "name": "value",
+          "type": "string",
+          "_index": 0,
+          "_path": "phoneNumbers.value",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.type",
+          "name": "type",
+          "type": "string",
+          "canonicalValues": [
+            "work",
+            "home",
+            "mobile",
+            "fax",
+            "pager",
+            "other"
+          ],
+          "_index": 1,
+          "_path": "phoneNumbers.type",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.primary",
+          "name": "primary",
+          "type": "boolean",
+          "_index": 2,
+          "_path": "phoneNumbers.primary",
+          "_annotations": ["@Primary"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.display",
+          "name": "display",
+          "type": "string",
+          "_index": 3,
+          "_path": "phoneNumbers.display"
+        }
+      ],
+      "_index": 113,
+      "_path": "phoneNumbers",
+      "_annotations": [
+        "@AutoCompact",
+        "@ExclusivePrimary"
+      ]
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:ims",
+      "name": "ims",
+      "type": "complex",
+      "multiValued": true,
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:ims.value",
+          "name": "value",
+          "type": "string",
+          "_index": 0,
+          "_path": "ims.value",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:ims.type",
+          "name": "type",
+          "type": "string",
+          "canonicalValues": [
+            "skype",
+            "qq",
+            "wechat",
+            "weibo",
+            "other"
+          ],
+          "_index": 1,
+          "_path": "ims.type",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:ims.primary",
+          "name": "primary",
+          "type": "boolean",
+          "_index": 2,
+          "_path": "ims.primary",
+          "_annotations": ["@Primary"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:ims.display",
+          "name": "display",
+          "type": "string",
+          "_index": 3,
+          "_path": "ims.display"
+        }
+      ],
+      "_index": 114,
+      "_path": "ims",
+      "_annotations": [
+        "@AutoCompact",
+        "@ExclusivePrimary"
+      ]
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:photos",
+      "name": "photos",
+      "type": "complex",
+      "multiValued": true,
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:photos.value",
+          "name": "value",
+          "type": "reference",
+          "referenceTypes": [
+            "external"
+          ],
+          "_index": 0,
+          "_path": "photos.value",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:photos.type",
+          "name": "type",
+          "type": "string",
+          "canonicalValues": [
+            "photo",
+            "thumbnail"
+          ],
+          "_index": 1,
+          "_path": "photos.type",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:photos.primary",
+          "name": "primary",
+          "type": "boolean",
+          "_index": 2,
+          "_path": "photos.primary",
+          "_annotations": ["@Primary"]
+        }
+      ],
+      "_index": 115,
+      "_path": "photos",
+      "_annotations": [
+        "@AutoCompact",
+        "@ExclusivePrimary"
+      ]
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:addresses",
+      "name": "addresses",
+      "type": "complex",
+      "multiValued": true,
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:addresses.formatted",
+          "name": "formatted",
+          "type": "string",
+          "_index": 0,
+          "_path": "photos.formatted"
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:addresses.streetAddress",
+          "name": "streetAddress",
+          "type": "string",
+          "_index": 1,
+          "_path": "photos.streetAddress",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:addresses.locality",
+          "name": "locality",
+          "type": "string",
+          "_index": 2,
+          "_path": "photos.locality",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:addresses.region",
+          "name": "region",
+          "type": "string",
+          "_index": 3,
+          "_path": "photos.region",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:addresses.postalCode",
+          "name": "postalCode",
+          "type": "string",
+          "_index": 4,
+          "_path": "photos.postalCode",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:addresses.country",
+          "name": "country",
+          "type": "string",
+          "_index": 5,
+          "_path": "photos.country",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:addresses.type",
+          "name": "type",
+          "type": "string",
+          "canonicalValues": [
+            "work",
+            "home",
+            "id",
+            "driver",
+            "other"
+          ],
+          "_index": 6,
+          "_path": "photos.type",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:addresses.primary",
+          "name": "primary",
+          "type": "boolean",
+          "_index": 7,
+          "_path": "photos.primary",
+          "_annotations": ["@Primary"]
+        }
+      ],
+      "_index": 116,
+      "_path": "addresses",
+      "_annotations": [
+        "@AutoCompact",
+        "@ExclusivePrimary"
+      ]
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:groups",
+      "name": "groups",
+      "type": "complex",
+      "multiValued": true,
+      "mutability": "readOnly",
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:groups.value",
+          "name": "value",
+          "type": "string",
+          "mutability": "readOnly",
+          "_index": 0,
+          "_path": "groups.value",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:groups.$ref",
+          "name": "$ref",
+          "type": "reference",
+          "mutability": "readOnly",
+          "_index": 1,
+          "_path": "groups.$ref",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:groups.type",
+          "name": "type",
+          "type": "string",
+          "mutability": "readOnly",
+          "canonicalValues": [
+            "direct",
+            "indirect"
+          ],
+          "_index": 2,
+          "_path": "groups.type"
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:groups.display",
+          "name": "display",
+          "type": "string",
+          "mutability": "readOnly",
+          "_index": 3,
+          "_path": "groups.display"
+        }
+      ],
+      "_index": 117,
+      "_path": "groups"
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:entitlements",
+      "name": "entitlements",
+      "type": "complex",
+      "multiValued": true,
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:entitlements.value",
+          "name": "value",
+          "type": "string",
+          "_index": 0,
+          "_path": "entitlements.value",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:entitlements.type",
+          "name": "type",
+          "type": "string",
+          "_index": 0,
+          "_path": "entitlements.type",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:entitlements.primary",
+          "name": "primary",
+          "type": "boolean",
+          "_index": 0,
+          "_path": "entitlements.primary",
+          "_annotations": ["@Primary"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:entitlements.display",
+          "name": "display",
+          "type": "string",
+          "_index": 0,
+          "_path": "entitlements.display"
+        }
+      ],
+      "_index": 118,
+      "_path": "entitlements",
+      "_annotations": [
+        "@AutoCompact",
+        "@ExclusivePrimary"
+      ]
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:roles",
+      "name": "roles",
+      "type": "complex",
+      "multiValued": true,
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:roles.value",
+          "name": "value",
+          "type": "string",
+          "_index": 0,
+          "_path": "roles.value",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:roles.type",
+          "name": "type",
+          "type": "string",
+          "_index": 1,
+          "_path": "roles.type",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:roles.primary",
+          "name": "primary",
+          "type": "boolean",
+          "_index": 2,
+          "_path": "roles.primary",
+          "_annotations": ["@Primary"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:roles.display",
+          "name": "display",
+          "type": "string",
+          "_index": 3,
+          "_path": "roles.display"
+        }
+      ],
+      "_index": 119,
+      "_path": "roles",
+      "_annotations": [
+        "@AutoCompact",
+        "@ExclusivePrimary"
+      ]
+    },
+    {
+      "id": "urn:ietf:params:scim:schemas:core:2.0:User:x509Certificates",
+      "name": "x509Certificates",
+      "type": "complex",
+      "multiValued": true,
+      "subAttributes": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:x509Certificates.value",
+          "name": "value",
+          "type": "binary",
+          "_index": 0,
+          "_path": "x509Certificates.value",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:x509Certificates.type",
+          "name": "type",
+          "type": "string",
+          "_index": 1,
+          "_path": "x509Certificates.type",
+          "_annotations": ["@Identity"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:x509Certificates.primary",
+          "name": "primary",
+          "type": "boolean",
+          "_index": 2,
+          "_path": "x509Certificates.primary",
+          "_annotations": ["@Primary"]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User:x509Certificates.display",
+          "name": "display",
+          "type": "string",
+          "_index": 3,
+          "_path": "x509Certificates.display"
+        }
+      ],
+      "_index": 120,
+      "_path": "x509Certificates",
+      "_annotations": [
+        "@AutoCompact",
+        "@ExclusivePrimary"
+      ]
+    }
+  ]
+}

--- a/server/public/sp_config/sp_config.json
+++ b/server/public/sp_config/sp_config.json
@@ -1,0 +1,52 @@
+{
+  "schemas":
+  ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+  "documentationUri": "http://example.com/help/scim.html",
+  "patch": {
+    "supported":true
+  },
+  "bulk": {
+    "supported":true,
+    "maxOperations":1000,
+    "maxPayloadSize":1048576
+  },
+  "filter": {
+    "supported":true,
+    "maxResults": 200
+  },
+  "changePassword": {
+    "supported":false
+  },
+  "sort": {
+    "supported":true
+  },
+  "etag": {
+    "supported":true
+  },
+  "authenticationSchemes": [
+    {
+      "name": "OAuth Bearer Token",
+      "description":
+      "Authentication scheme using the OAuth Bearer Token Standard",
+      "specUri": "http://www.rfc-editor.org/info/rfc6750",
+      "documentationUri": "http://example.com/help/oauth.html",
+      "type": "oauthbearertoken",
+      "primary": true
+    },
+    {
+      "name": "HTTP Basic",
+      "description":
+      "Authentication scheme using the HTTP Basic Standard",
+      "specUri": "http://www.rfc-editor.org/info/rfc2617",
+      "documentationUri": "http://example.com/help/httpBasic.html",
+      "type": "httpbasic"
+    }
+  ],
+  "meta": {
+    "location": "https://example.com/v2/ServiceProviderConfig",
+    "resourceType": "ServiceProviderConfig",
+    "created": "2010-01-23T04:56:22Z",
+    "lastModified": "2011-05-13T04:42:34Z",
+    "version": "W\/\"3694e05e9dff594\""
+  }
+}


### PR DESCRIPTION
This introduces a Dockerfile for the base repository, so that the build context can encompass the packages other than server, which is why the build context declared in the `docker-compose.yml` is `../.`

For this to be a working example I needed to include the basic service, resource and schema documents. So I followed the rubric set forth in the mongo package, using `/public` for these files.

The app containers `api` and `groupsync` start really fast, so I included a helper function that will continue to attempt connecting to the rabbit instance until it either succeeds or reaches the provided timeout.