### PR TITLE
fix(pkg): fix replace patch behavior on root property

### DIFF
--- a/pkg/v2/crud/crud_test.go
+++ b/pkg/v2/crud/crud_test.go
@@ -241,8 +241,7 @@ func (s *CrudTestSuite) TestReplace() {
 						"primary": true,
 					},
 					map[string]interface{}{
-						"value":   "baz",
-						"primary": nil,
+						"value": "baz",
 					},
 				}, r.Navigator().Dot("emails").Current().Raw())
 			},
@@ -380,11 +379,10 @@ func (s *CrudTestSuite) TestDelete() {
 				assert.Equal(t, []interface{}{
 					map[string]interface{}{
 						"value":   "foo",
-						"primary": nil,
+						"primary": nil, // nil is present because it's dirty now
 					},
 					map[string]interface{}{
-						"value":   "bar",
-						"primary": nil,
+						"value": "bar",
 					},
 				}, r.Navigator().Dot("emails").Current().Raw())
 			},

--- a/pkg/v2/prop/complex.go
+++ b/pkg/v2/prop/complex.go
@@ -62,7 +62,9 @@ func (p *complexProperty) Attribute() *spec.Attribute {
 func (p *complexProperty) Raw() interface{} {
 	values := map[string]interface{}{}
 	_ = p.ForEachChild(func(_ int, child Property) error {
-		values[child.Attribute().Name()] = child.Raw()
+		if child.Dirty() {
+			values[child.Attribute().Name()] = child.Raw()
+		}
 		return nil
 	})
 	return values
@@ -195,10 +197,6 @@ func (p *complexProperty) Replace(value interface{}) (*Event, error) {
 	}
 
 	wasUnassigned := p.IsUnassigned()
-
-	if _, err := p.Delete(); err != nil {
-		return nil, err
-	}
 
 	if _, err := p.Add(value); err != nil {
 		return nil, err

--- a/pkg/v2/prop/complex_test.go
+++ b/pkg/v2/prop/complex_test.go
@@ -139,10 +139,7 @@ func (s *ComplexPropertyTestSuite) TestRaw() {
 				return nil
 			},
 			expect: func(t *testing.T, raw interface{}) {
-				assert.Equal(t, map[string]interface{}{
-					"givenName":  nil,
-					"familyName": nil,
-				}, raw)
+				assert.Equal(t, map[string]interface{}{}, raw)
 			},
 		},
 		{
@@ -360,8 +357,7 @@ func (s *ComplexPropertyTestSuite) TestAdd() {
 			expect: func(t *testing.T, raw interface{}, err error) {
 				assert.Nil(t, err)
 				assert.Equal(t, map[string]interface{}{
-					"givenName":  "David",
-					"familyName": nil,
+					"givenName": "David",
 				}, raw)
 			},
 		},
@@ -435,7 +431,7 @@ func (s *ComplexPropertyTestSuite) TestReplace() {
 				assert.Nil(t, err)
 				assert.Equal(t, map[string]interface{}{
 					"givenName":  "David",
-					"familyName": nil,
+					"familyName": "Q", // if replace partial data, the rest will still be present
 				}, raw)
 			},
 		},

--- a/pkg/v2/prop/subscriber_test.go
+++ b/pkg/v2/prop/subscriber_test.go
@@ -156,8 +156,7 @@ func TestExclusivePrimarySubscriber(t *testing.T) {
 						"primary": true,
 					},
 					map[string]interface{}{
-						"value":   "bar",
-						"primary": nil,
+						"value": "bar",
 					},
 				}, raw)
 			},
@@ -182,11 +181,10 @@ func TestExclusivePrimarySubscriber(t *testing.T) {
 				assert.Equal(t, []interface{}{
 					map[string]interface{}{
 						"value":   "foo",
-						"primary": nil,
+						"primary": nil, // this nil will be present because it is dirty
 					},
 					map[string]interface{}{
-						"value":   "bar",
-						"primary": nil,
+						"value": "bar",
 					},
 				}, raw)
 			},

--- a/pkg/v2/service/create_test.go
+++ b/pkg/v2/service/create_test.go
@@ -80,14 +80,9 @@ func (s *CreateServiceTestSuite) TestDo() {
 					map[string]interface{}{
 						"value":   "foo@bar.com",
 						"primary": true,
-						"display": nil,
-						"type":    nil,
 					},
 					map[string]interface{}{
-						"value":   "bar@foo.com",
-						"primary": nil,
-						"display": nil,
-						"type":    nil,
+						"value": "bar@foo.com",
 					},
 				}, n().Dot("emails").Current().Raw())
 				assert.NotEmpty(t, n().Dot("id").Current().Raw())

--- a/pkg/v2/service/patch.go
+++ b/pkg/v2/service/patch.go
@@ -234,7 +234,7 @@ func (o *PatchOperation) ParseValue(resource *prop.Resource) (interface{}, error
 	}
 
 	p := prop.NewProperty(attr)
-	if err := scimjson.DeserializeProperty(o.Value, p, o.Op == "add"); err != nil {
+	if err := scimjson.DeserializeProperty(o.Value, p, strings.ToLower(o.Op) == "add"); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fix issue 57 where a replace patch operation on the root property would
erase all other un-mentioned properties. The issue was identified to be
that ComplexProperty.Raw() returns nil properties for all sub
properties, regardless of whether they are dirty or not, which leads to
the patch operation payload contains lots of nil-valued fields which
should not be present; in addition, ComplexProperty.Replace deletes all
sub properties before adding to them, effectively replacing the original
sub properties with nil value unless they are present in the new value
payload.

The fix is two part: first, ComplexProperty.Raw() now only
returns sub properties if they are dirty (untouched sub properties are
no longer returned), this would break some tests (fixed also in this
commit) but the overall behaviour is not changed; second,
ComplexProperty.Replace no longer eraises entire property before adding
the new value, this also will break some tests (fixed also in this
commit) but we will be fine since only the patch operations and tests
will actually use ComplexProperty.Replace feature. As a result, this fix
will not be considered breaking.

Closes 57