### PR TITLE
fix(pkg): Fix bug where projection parameters were mistakenly delimit…

### DIFF
--- a/pkg/v2/handlerutil/request.go
+++ b/pkg/v2/handlerutil/request.go
@@ -27,7 +27,7 @@ const (
 func GetRequestProjection(request *http.Request) (projection *crud.Projection, err error) {
 	if attrValue := request.URL.Query().Get(paramAttributes); len(attrValue) > 0 {
 		projection = &crud.Projection{
-			Attributes: strings.Split(strings.TrimSpace(attrValue), " "),
+			Attributes: strings.Split(strings.TrimSpace(attrValue), ","),
 		}
 	}
 
@@ -37,7 +37,7 @@ func GetRequestProjection(request *http.Request) (projection *crud.Projection, e
 			return
 		}
 		projection = &crud.Projection{
-			ExcludedAttributes: strings.Split(strings.TrimSpace(exclAttrValue), " "),
+			ExcludedAttributes: strings.Split(strings.TrimSpace(exclAttrValue), ","),
 		}
 	}
 

--- a/pkg/v2/handlerutil/request_test.go
+++ b/pkg/v2/handlerutil/request_test.go
@@ -34,7 +34,7 @@ func TestGetRequestProjection(t *testing.T) {
 			requestFunc: func() *http.Request {
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.URL.RawQuery = url.Values{
-					paramAttributes: []string{"foo bar baz"},
+					paramAttributes: []string{"foo,bar,baz"},
 				}.Encode()
 				return r
 			},
@@ -49,7 +49,7 @@ func TestGetRequestProjection(t *testing.T) {
 			requestFunc: func() *http.Request {
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.URL.RawQuery = url.Values{
-					paramExcludedAttributes: []string{"foo bar baz"},
+					paramExcludedAttributes: []string{"foo,bar,baz"},
 				}.Encode()
 				return r
 			},
@@ -64,8 +64,8 @@ func TestGetRequestProjection(t *testing.T) {
 			requestFunc: func() *http.Request {
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.URL.RawQuery = url.Values{
-					paramAttributes:         []string{"foo bar baz"},
-					paramExcludedAttributes: []string{"foo bar baz"},
+					paramAttributes:         []string{"foo,bar,baz"},
+					paramExcludedAttributes: []string{"foo,bar,baz"},
 				}.Encode()
 				return r
 			},


### PR DESCRIPTION
…ed by space

The projection parameters "attributes" and "excludedAttributes" shall
include one or more property paths delimited by comma(","), not space("
").

Closes 62