### PR TITLE
fix(pkg, cmd): Compiling a path to schema extension fields fails

### DIFF
--- a/cmd/api/context.go
+++ b/cmd/api/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/imulab/go-scim/cmd/internal/groupsync"
 	scimmongo "github.com/imulab/go-scim/mongo/v2"
+	"github.com/imulab/go-scim/pkg/v2/crud"
 	"github.com/imulab/go-scim/pkg/v2/db"
 	"github.com/imulab/go-scim/pkg/v2/service"
 	"github.com/imulab/go-scim/pkg/v2/service/filter"
@@ -73,6 +74,7 @@ func (ctx *applicationContext) UserResourceType() *spec.ResourceType {
 			panic(err)
 		}
 		ctx.userResourceType = u
+		crud.Register(ctx.userResourceType)
 		ctx.logInitialized("user resource type")
 	}
 	return ctx.userResourceType
@@ -87,6 +89,7 @@ func (ctx *applicationContext) GroupResourceType() *spec.ResourceType {
 			panic(err)
 		}
 		ctx.groupResourceType = g
+		crud.Register(ctx.groupResourceType)
 		ctx.logInitialized("group resource type")
 	}
 	return ctx.groupResourceType

--- a/pkg/v2/crud/crud_test.go
+++ b/pkg/v2/crud/crud_test.go
@@ -159,6 +159,18 @@ func (s *CrudTestSuite) TestAdd() {
 				}, r.Navigator().Dot("emails").Current().Raw())
 			},
 		},
+		{
+			name: "add to an extension schema field",
+			getResource: func(t *testing.T) *prop.Resource {
+				return prop.NewResource(s.resourceType)
+			},
+			path:  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber",
+			value: "6546579",
+			expect: func(t *testing.T, r *prop.Resource, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, "6546579", r.Navigator().Dot("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User").Dot("employeeNumber").Current().Raw())
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -460,6 +472,10 @@ func (s *CrudTestSuite) SetupSuite() {
 	require.Nil(s.T(), json.Unmarshal([]byte(testMainSchema), schema))
 	spec.Schemas().Register(schema)
 
+	schemaExtension := new(spec.Schema)
+	require.Nil(s.T(), json.Unmarshal([]byte(testSchemaExtension), schemaExtension))
+	spec.Schemas().Register(schemaExtension)
+
 	s.resourceType = new(spec.ResourceType)
 	require.Nil(s.T(), json.Unmarshal([]byte(testResourceType), s.resourceType))
 	Register(s.resourceType)
@@ -563,11 +579,32 @@ const (
   ]
 }
 `
+	testSchemaExtension = `
+{
+  "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+  "name": "Enterprise User",
+  "attributes": [
+    {
+      "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber",
+      "name": "employeeNumber",
+      "type": "string",
+      "_index": 100,
+      "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber"
+    }
+  ]
+}
+`
 	testResourceType = `
 {
   "id": "Test",
   "name": "Test",
-  "schema": "main"
+  "schema": "main",
+  "schemaExtensions": [
+    {
+      "schema": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+      "required": false
+    }
+  ]
 }
 `
 )

--- a/pkg/v2/groupsync/sync_test.go
+++ b/pkg/v2/groupsync/sync_test.go
@@ -3,6 +3,7 @@ package groupsync
 import (
 	"context"
 	"encoding/json"
+	"github.com/imulab/go-scim/pkg/v2/crud"
 	"github.com/imulab/go-scim/pkg/v2/db"
 	"github.com/imulab/go-scim/pkg/v2/prop"
 	"github.com/imulab/go-scim/pkg/v2/spec"
@@ -137,6 +138,13 @@ func (s *SyncServiceTestSuite) SetupSuite() {
 			},
 		},
 		{
+			filepath:  "../../../public/schemas/user_enterprise_extension_schema.json",
+			structure: new(spec.Schema),
+			post: func(parsed interface{}) {
+				spec.Schemas().Register(parsed.(*spec.Schema))
+			},
+		},
+		{
 			filepath:  "../../../public/schemas/group_schema.json",
 			structure: new(spec.Schema),
 			post: func(parsed interface{}) {
@@ -148,6 +156,7 @@ func (s *SyncServiceTestSuite) SetupSuite() {
 			structure: new(spec.ResourceType),
 			post: func(parsed interface{}) {
 				s.userResourceType = parsed.(*spec.ResourceType)
+				crud.Register(s.userResourceType)
 			},
 		},
 		{
@@ -155,6 +164,7 @@ func (s *SyncServiceTestSuite) SetupSuite() {
 			structure: new(spec.ResourceType),
 			post: func(parsed interface{}) {
 				s.groupResourceType = parsed.(*spec.ResourceType)
+				crud.Register(s.groupResourceType)
 			},
 		},
 	} {

--- a/pkg/v2/json/adapt_test.go
+++ b/pkg/v2/json/adapt_test.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"encoding/json"
+	"github.com/imulab/go-scim/pkg/v2/crud"
 	"github.com/imulab/go-scim/pkg/v2/spec"
 	"github.com/stretchr/testify/assert"
 	"os"
@@ -17,12 +18,22 @@ func TestResourceTypeToSerializable(t *testing.T) {
 	assert.Nil(t, err)
 	spec.Schemas().Register(sch)
 
+	f, err = os.Open("../../../public/schemas/user_enterprise_extension_schema.json")
+	assert.Nil(t, err)
+
+	schExt := new(spec.Schema)
+	err = json.NewDecoder(f).Decode(schExt)
+	assert.Nil(t, err)
+	spec.Schemas().Register(schExt)
+
 	f, err = os.Open("../../../public/resource_types/user_resource_type.json")
 	assert.Nil(t, err)
 
 	rt := new(spec.ResourceType)
 	err = json.NewDecoder(f).Decode(rt)
 	assert.Nil(t, err)
+
+	crud.Register(rt)
 
 	raw, err := Serialize(ResourceTypeToSerializable(rt))
 	assert.Nil(t, err)
@@ -39,7 +50,13 @@ func TestResourceTypeToSerializable(t *testing.T) {
   },
   "name": "User",
   "endpoint": "/Users",
-  "schema": "urn:ietf:params:scim:schemas:core:2.0:User"
+  "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
+  "schemaExtensions": [
+    {
+      "schema": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+      "required": false
+    }
+  ]
 }
 
 `

--- a/pkg/v2/service/create_test.go
+++ b/pkg/v2/service/create_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/imulab/go-scim/pkg/v2/crud"
 	"github.com/imulab/go-scim/pkg/v2/db"
 	"github.com/imulab/go-scim/pkg/v2/prop"
 	"github.com/imulab/go-scim/pkg/v2/service/filter"
@@ -183,10 +184,18 @@ func (s *CreateServiceTestSuite) SetupSuite() {
 			},
 		},
 		{
+			filepath:  "../../../public/schemas/user_enterprise_extension_schema.json",
+			structure: new(spec.Schema),
+			post: func(parsed interface{}) {
+				spec.Schemas().Register(parsed.(*spec.Schema))
+			},
+		},
+		{
 			filepath:  "../../../public/resource_types/user_resource_type.json",
 			structure: new(spec.ResourceType),
 			post: func(parsed interface{}) {
 				s.resourceType = parsed.(*spec.ResourceType)
+				crud.Register(s.resourceType)
 			},
 		},
 	} {

--- a/pkg/v2/service/delete_test.go
+++ b/pkg/v2/service/delete_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/imulab/go-scim/pkg/v2/crud"
 	"github.com/imulab/go-scim/pkg/v2/db"
 	"github.com/imulab/go-scim/pkg/v2/prop"
 	"github.com/imulab/go-scim/pkg/v2/spec"
@@ -104,10 +105,18 @@ func (s *DeleteServiceTestSuite) SetupSuite() {
 			},
 		},
 		{
+			filepath:  "../../../public/schemas/user_enterprise_extension_schema.json",
+			structure: new(spec.Schema),
+			post: func(parsed interface{}) {
+				spec.Schemas().Register(parsed.(*spec.Schema))
+			},
+		},
+		{
 			filepath:  "../../../public/resource_types/user_resource_type.json",
 			structure: new(spec.ResourceType),
 			post: func(parsed interface{}) {
 				s.resourceType = parsed.(*spec.ResourceType)
+				crud.Register(s.resourceType)
 			},
 		},
 	} {

--- a/pkg/v2/service/filter/meta_test.go
+++ b/pkg/v2/service/filter/meta_test.go
@@ -3,6 +3,7 @@ package filter
 import (
 	"context"
 	"encoding/json"
+	"github.com/imulab/go-scim/pkg/v2/crud"
 	"github.com/imulab/go-scim/pkg/v2/prop"
 	"github.com/imulab/go-scim/pkg/v2/spec"
 	"github.com/stretchr/testify/assert"
@@ -187,10 +188,18 @@ func (s *MetaFilterTestSuite) SetupSuite() {
 			},
 		},
 		{
+			filepath:  "../../../../public/schemas/user_enterprise_extension_schema.json",
+			structure: new(spec.Schema),
+			post: func(parsed interface{}) {
+				spec.Schemas().Register(parsed.(*spec.Schema))
+			},
+		},
+		{
 			filepath:  "../../../../public/resource_types/user_resource_type.json",
 			structure: new(spec.ResourceType),
 			post: func(parsed interface{}) {
 				s.resourceType = parsed.(*spec.ResourceType)
+				crud.Register(s.resourceType)
 			},
 		},
 	} {

--- a/pkg/v2/service/get_test.go
+++ b/pkg/v2/service/get_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/imulab/go-scim/pkg/v2/crud"
 	"github.com/imulab/go-scim/pkg/v2/db"
 	"github.com/imulab/go-scim/pkg/v2/prop"
 	"github.com/imulab/go-scim/pkg/v2/spec"
@@ -105,10 +106,18 @@ func (s *GetServiceTestSuite) SetupSuite() {
 			},
 		},
 		{
+			filepath:  "../../../public/schemas/user_enterprise_extension_schema.json",
+			structure: new(spec.Schema),
+			post: func(parsed interface{}) {
+				spec.Schemas().Register(parsed.(*spec.Schema))
+			},
+		},
+		{
 			filepath:  "../../../public/resource_types/user_resource_type.json",
 			structure: new(spec.ResourceType),
 			post: func(parsed interface{}) {
 				s.resourceType = parsed.(*spec.ResourceType)
+				crud.Register(s.resourceType)
 			},
 		},
 	} {

--- a/pkg/v2/service/query_test.go
+++ b/pkg/v2/service/query_test.go
@@ -198,10 +198,18 @@ func (s *QueryServiceTestSuite) SetupSuite() {
 			},
 		},
 		{
+			filepath:  "../../../public/schemas/user_enterprise_extension_schema.json",
+			structure: new(spec.Schema),
+			post: func(parsed interface{}) {
+				spec.Schemas().Register(parsed.(*spec.Schema))
+			},
+		},
+		{
 			filepath:  "../../../public/resource_types/user_resource_type.json",
 			structure: new(spec.ResourceType),
 			post: func(parsed interface{}) {
 				s.resourceType = parsed.(*spec.ResourceType)
+				crud.Register(s.resourceType)
 			},
 		},
 	} {

--- a/pkg/v2/service/replace_test.go
+++ b/pkg/v2/service/replace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/imulab/go-scim/pkg/v2/crud"
 	"github.com/imulab/go-scim/pkg/v2/db"
 	"github.com/imulab/go-scim/pkg/v2/prop"
 	"github.com/imulab/go-scim/pkg/v2/service/filter"
@@ -210,10 +211,18 @@ func (s *ReplaceServiceTestSuite) SetupSuite() {
 			},
 		},
 		{
+			filepath:  "../../../public/schemas/user_enterprise_extension_schema.json",
+			structure: new(spec.Schema),
+			post: func(parsed interface{}) {
+				spec.Schemas().Register(parsed.(*spec.Schema))
+			},
+		},
+		{
 			filepath:  "../../../public/resource_types/user_resource_type.json",
 			structure: new(spec.ResourceType),
 			post: func(parsed interface{}) {
 				s.resourceType = parsed.(*spec.ResourceType)
+				crud.Register(s.resourceType)
 			},
 		},
 	} {


### PR DESCRIPTION
Compilation to schema extension field paths fail because we didn't call
`crud.Register` for the respective resource type during initialization.
This was fixed now in the context setup, and various tests involving
parsing of the resource type also got everything correctly registered.

Closes 72